### PR TITLE
chore: separate N8N_API_KEY comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Upsert workflow in n8n
         env:
           N8N_URL: ${{ secrets.N8N_URL }}        # مثال: http://127.0.0.1:5678 أو https://your-n8n.example.com
-          N8N_API_KEY: ${{ secrets.N8N_API_KEY }}# Personal Access Token من n8n
+          N8N_API_KEY: ${{ secrets.N8N_API_KEY }}  # Personal Access Token من n8n
         run: |
           set -e
           WF_FILE="workflows/sehaty.json"


### PR DESCRIPTION
## Summary
- ensure N8N_API_KEY comment is separated from its value in deploy workflow

## Testing
- `yamllint .github/workflows/deploy.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68bc320b31e0833085b40fc4289c9f1e