### PR TITLE
Ensure deploy workflow detects curl HTTP errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,20 +18,28 @@ jobs:
 
       - name: Upsert workflow in n8n
         env:
-          N8N_URL: ${{ secrets.N8N_URL }}        # مثال: http://127.0.0.1:5678 أو https://your-n8n.example.com
-          N8N_API_KEY: ${{ secrets.N8N_API_KEY }}# Personal Access Token من n8n
+          N8N_URL: ${{ secrets.N8N_URL }}        # e.g., http://localhost:5678
+          N8N_API_KEY: ${{ secrets.N8N_API_KEY }} # n8n personal access token
         run: |
-          set -e
+          set -eo pipefail
           WF_FILE="workflows/sehaty.json"
           NAME=$(jq -r '.name' "$WF_FILE")
 
-          EXIST=$(curl -sS -H "X-N8N-API-KEY: $N8N_API_KEY" "$N8N_URL/api/v1/workflows?filter[name]=$NAME")
+          EXIST=$(curl -sS --fail \
+            -H "X-N8N-API-KEY: $N8N_API_KEY" \
+            "$N8N_URL/api/v1/workflows?filter[name]=$NAME")
           WF_ID=$(echo "$EXIST" | jq -r '.[0].id // empty')
 
           if [ -z "$WF_ID" ] || [ "$WF_ID" = "null" ]; then
             echo "Creating new workflow: $NAME"
-            curl -sS -X POST "$N8N_URL/api/v1/workflows"               -H "Content-Type: application/json"               -H "X-N8N-API-KEY: $N8N_API_KEY"               --data @"$WF_FILE"
+            curl -sS --fail -X POST "$N8N_URL/api/v1/workflows" \
+              -H "Content-Type: application/json" \
+              -H "X-N8N-API-KEY: $N8N_API_KEY" \
+              --data @"$WF_FILE"
           else
             echo "Updating workflow id=$WF_ID name=$NAME"
-            curl -sS -X PUT "$N8N_URL/api/v1/workflows/$WF_ID"               -H "Content-Type: application/json"               -H "X-N8N-API-KEY: $N8N_API_KEY"               --data @"$WF_FILE"
+            curl -sS --fail -X PUT "$N8N_URL/api/v1/workflows/$WF_ID" \
+              -H "Content-Type: application/json" \
+              -H "X-N8N-API-KEY: $N8N_API_KEY" \
+              --data @"$WF_FILE"
           fi


### PR DESCRIPTION
## Summary
- add `--fail` and pipefail to n8n deployment workflow for proper error surfacing

## Testing
- `yamllint .github/workflows/deploy.yml`
- `bash -eo pipefail -c 'curl -sS --fail http://127.0.0.1:8000/ > /tmp/ok && echo first-ok && curl -sS --fail http://127.0.0.1:8000/doesnotexist'`

------
https://chatgpt.com/codex/tasks/task_e_68bc33392200833093e6bd5e6867828f